### PR TITLE
[fix]유저 정보 반환에서 등급과 닉네임이 반대로 나오는 현상 해결

### DIFF
--- a/src/main/java/com/running/you_run/running/service/TrackService.java
+++ b/src/main/java/com/running/you_run/running/service/TrackService.java
@@ -85,8 +85,8 @@ public class TrackService {
                     User user = userMap.get(entity.getUserId());
                     return new TrackRecordDto(
                             entity.getUserId(),
-                            user.getGrade().getName(),
                             user.getName(),
+                            user.getGrade().getName(),
                             user.getLevel(),
                             (long) entity.getResultTime() // Use the pre-calculated time
                     );


### PR DESCRIPTION
## #️⃣연관된 이슈

#17 

## 📝작업 내용

유저 정보 반환에서 등급과 닉네임이 반대로 나오는 현상 해결

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
