### PR TITLE
feat: 아바타(Avatar) 구매/선택/소유 관련 백엔드 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.3'
 	id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.jetbrains.kotlin.jvm'
 }
 
 group = 'com.running'
@@ -52,6 +53,7 @@ dependencies {
 
 	implementation 'com.google.zxing:core:3.5.2'
 	implementation 'com.google.zxing:javase:3.5.2'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 }
 
 tasks.named('test') {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,6 @@
+pluginManagement {
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version '2.1.21'
+    }
+}
 rootProject.name = 'you-run'

--- a/src/main/java/com/running/you_run/global/exception/ErrorCode.java
+++ b/src/main/java/com/running/you_run/global/exception/ErrorCode.java
@@ -24,8 +24,11 @@ public enum ErrorCode {
     INVALID_TRACK_PATH(HttpStatus.BAD_REQUEST,"800-2","유효하지 않은 트랙입니다."),
     INSUFFICIENT_TRACK_POINTS(HttpStatus.BAD_REQUEST, "800-3", "트랙 저장에 충분하지 않은 포인트 수입니다."),
 
-    RECORD_NOT_EXIST(HttpStatus.BAD_REQUEST, "900-1", "존재하지 않는 기록입니다.");
-
+    RECORD_NOT_EXIST(HttpStatus.BAD_REQUEST, "900-1", "존재하지 않는 기록입니다."),
+    AVATAR_NOT_EXIST(HttpStatus.BAD_REQUEST, "720-1", "존재하지 않는 아바타입니다."),
+    AVATAR_ALREADY_OWNED(HttpStatus.BAD_REQUEST, "720-2", "이미 소유한 아바타입니다."),
+    AVATAR_INSUFFICIENT_POINT(HttpStatus.BAD_REQUEST, "720-3", "포인트가 부족합니다."),
+    AVATAR_NOT_OWNED(HttpStatus.BAD_REQUEST, "720-4", "소유하지 않은 아바타는 선택할 수 없습니다.");
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/com/running/you_run/user/Enum/Gender.java
+++ b/src/main/java/com/running/you_run/user/Enum/Gender.java
@@ -1,0 +1,6 @@
+package com.running.you_run.user.Enum;
+
+public enum Gender {
+    MALE,
+    FEMALE
+} 

--- a/src/main/java/com/running/you_run/user/controller/AvatarController.java
+++ b/src/main/java/com/running/you_run/user/controller/AvatarController.java
@@ -1,0 +1,43 @@
+package com.running.you_run.user.controller;
+
+import com.running.you_run.user.entity.User;
+import com.running.you_run.user.repository.UserRepository;
+import com.running.you_run.user.service.AvatarService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/avatars")
+@RequiredArgsConstructor
+public class AvatarController {
+    private final AvatarService avatarService;
+    private final UserRepository userRepository;
+
+    // TODO: 실제 환경에서는 Principal 또는 인증 정보를 통해 User 객체를 받아와야 함
+
+    // 1. 모든 아바타 목록 조회 (소유 여부 포함)
+    @GetMapping
+    public ResponseEntity<List<AvatarService.AvatarWithOwnershipDto>> getAllAvatars() {
+        User user = userRepository.findById(1L).orElseThrow(() -> new RuntimeException("User not found"));
+        return ResponseEntity.ok(avatarService.getAllAvatarsWithOwnership(user));
+    }
+
+    // 2. 아바타 구매
+    @PostMapping("/{avatarId}/purchase")
+    public ResponseEntity<Void> purchaseAvatar(@PathVariable Long avatarId) {
+        User user = userRepository.findById(1L).orElseThrow(() -> new RuntimeException("User not found"));
+        avatarService.purchaseAvatar(user, avatarId);
+        return ResponseEntity.ok().build();
+    }
+
+    // 3. 선택 아바타 변경
+    @PostMapping("/{avatarId}/select")
+    public ResponseEntity<Void> selectAvatar(@PathVariable Long avatarId) {
+        User user = userRepository.findById(1L).orElseThrow(() -> new RuntimeException("User not found"));
+        avatarService.selectAvatar(user, avatarId);
+        return ResponseEntity.ok().build();
+    }
+} 

--- a/src/main/java/com/running/you_run/user/entity/Avatar.java
+++ b/src/main/java/com/running/you_run/user/entity/Avatar.java
@@ -1,0 +1,33 @@
+package com.running.you_run.user.entity;
+
+import com.running.you_run.user.Enum.Gender;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Avatar {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String imageUrl; // .png
+
+    @Column(nullable = false)
+    private String glbUrl;   // .glb
+
+    @Column(nullable = false)
+    private int price;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Gender gender;
+}

--- a/src/main/java/com/running/you_run/user/entity/User.java
+++ b/src/main/java/com/running/you_run/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.running.you_run.user.entity;
 
+import com.running.you_run.user.Enum.Gender;
 import com.running.you_run.user.Enum.UserGrade;
 import com.running.you_run.user.Enum.UserRole;
 import com.running.you_run.user.payload.request.UserUpdateProfileReqeust;
@@ -77,7 +78,15 @@ public class User {
     @Column
     private Long totalDistance;
 
+    @Column
+    @Enumerated(EnumType.STRING)
+    @Setter
+    private Gender gender;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "selected_avatar_id")
+    @Setter
+    private Avatar selectedAvatar;
 
     @Column(unique = true)
     private String code;
@@ -125,5 +134,9 @@ public class User {
         this.point += point;
         this.level = newLevel;
         this.grade = UserGrade.fromTotalDistance(this.level);
+    }
+
+    public void setPoint(long point) {
+        this.point = point;
     }
 }

--- a/src/main/java/com/running/you_run/user/entity/UserAvatar.java
+++ b/src/main/java/com/running/you_run/user/entity/UserAvatar.java
@@ -1,0 +1,34 @@
+package com.running.you_run.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "user_avatar")
+public class UserAvatar {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "avatar_id", nullable = false)
+    private Avatar avatar;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @Column(name = "is_selected", nullable = false)
+    private boolean selected;
+}

--- a/src/main/java/com/running/you_run/user/repository/AvatarRepository.java
+++ b/src/main/java/com/running/you_run/user/repository/AvatarRepository.java
@@ -1,0 +1,7 @@
+package com.running.you_run.user.repository;
+
+import com.running.you_run.user.entity.Avatar;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AvatarRepository extends JpaRepository<Avatar, Long> {
+} 

--- a/src/main/java/com/running/you_run/user/repository/UserAvatarRepository.java
+++ b/src/main/java/com/running/you_run/user/repository/UserAvatarRepository.java
@@ -1,0 +1,14 @@
+package com.running.you_run.user.repository;
+
+import com.running.you_run.user.entity.Avatar;
+import com.running.you_run.user.entity.User;
+import com.running.you_run.user.entity.UserAvatar;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserAvatarRepository extends JpaRepository<UserAvatar, Long> {
+    List<UserAvatar> findByUser(User user);
+    Optional<UserAvatar> findByUserAndAvatar(User user, Avatar avatar);
+} 

--- a/src/main/java/com/running/you_run/user/service/AvatarService.java
+++ b/src/main/java/com/running/you_run/user/service/AvatarService.java
@@ -1,0 +1,95 @@
+package com.running.you_run.user.service;
+
+import com.running.you_run.global.exception.ApiException;
+import com.running.you_run.global.exception.ErrorCode;
+import com.running.you_run.user.entity.Avatar;
+import com.running.you_run.user.entity.User;
+import com.running.you_run.user.entity.UserAvatar;
+import com.running.you_run.user.repository.AvatarRepository;
+import com.running.you_run.user.repository.UserAvatarRepository;
+import com.running.you_run.user.repository.UserRepository;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AvatarService {
+    private final AvatarRepository avatarRepository;
+    private final UserAvatarRepository userAvatarRepository;
+    private final UserRepository userRepository;
+
+    // 아바타 + 소유 여부 DTO
+    @Getter
+    @AllArgsConstructor
+    public static class AvatarWithOwnershipDto {
+        private Avatar avatar;
+        private boolean owned;
+    }
+
+    // 1. 모든 아바타 목록 조회 (소유 여부 포함)
+    public List<AvatarWithOwnershipDto> getAllAvatarsWithOwnership(User user) {
+        List<Avatar> avatars = avatarRepository.findAll();
+        List<UserAvatar> userAvatars = userAvatarRepository.findByUser(user);
+        // 소유한 아바타 id 집합
+        java.util.Set<Long> ownedAvatarIds = userAvatars.stream()
+                .map(ua -> ua.getAvatar().getId())
+                .collect(java.util.stream.Collectors.toSet());
+        // DTO 변환
+        return avatars.stream()
+                .map(avatar -> new AvatarWithOwnershipDto(avatar, ownedAvatarIds.contains(avatar.getId())))
+                .toList();
+    }
+
+    // 2. 사용자의 소유 아바타 목록 조회
+    public List<UserAvatar> getUserAvatars(User user) {
+        return userAvatarRepository.findByUser(user);
+    }
+
+    // 3. 아바타 구매
+    @Transactional
+    public void purchaseAvatar(User user, Long avatarId) {
+        Avatar avatar = avatarRepository.findById(avatarId)
+                .orElseThrow(() -> new ApiException(ErrorCode.AVATAR_NOT_EXIST));
+        // 이미 소유한 경우
+        if (userAvatarRepository.findByUserAndAvatar(user, avatar).isPresent()) {
+            throw new ApiException(ErrorCode.AVATAR_ALREADY_OWNED);
+        }
+        // 포인트 부족
+        if (user.getPoint() < avatar.getPrice()) {
+            throw new ApiException(ErrorCode.AVATAR_INSUFFICIENT_POINT);
+        }
+        // 포인트 차감
+        user.setPoint(user.getPoint() - avatar.getPrice());
+        // 소유 추가
+        UserAvatar userAvatar = UserAvatar.builder()
+                .user(user)
+                .avatar(avatar)
+                .selected(false)
+                .build();
+        userAvatarRepository.save(userAvatar);
+        // (선택) 첫 구매라면 선택 아바타로 설정
+        if (user.getSelectedAvatar() == null) {
+            user.setSelectedAvatar(avatar);
+        }
+    }
+
+    // 4. 선택 아바타 변경
+    @Transactional
+    public void selectAvatar(User user, Long avatarId) {
+        Avatar avatar = avatarRepository.findById(avatarId)
+                .orElseThrow(() -> new ApiException(ErrorCode.AVATAR_NOT_EXIST));
+        UserAvatar userAvatar = userAvatarRepository.findByUserAndAvatar(user, avatar)
+                .orElseThrow(() -> new ApiException(ErrorCode.AVATAR_NOT_OWNED));
+        // User의 선택 아바타 변경
+        user.setSelectedAvatar(avatar);
+        // 모든 UserAvatar의 selected false로 초기화 후, 해당 아바타만 true
+        userAvatarRepository.findByUser(user).forEach(ua -> {
+            ua.setSelected(ua.getAvatar().getId().equals(avatarId));
+        });
+    }
+} 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,4 @@
+INSERT INTO avatar (name, image_url, glb_url, price, gender) VALUES
+('기본 아바타', 'default.png', 'default.glb', 0, 'MALE'),
+('스포츠 아바타', 'sport.png', 'sport.glb', 100, 'FEMALE'),
+('럭셔리 아바타', 'luxury.png', 'luxury.glb', 500, 'MALE'); 


### PR DESCRIPTION
- Avatar, UserAvatar 엔티티 설계 및 DB 컬럼 정비
- 아바타 구매/선택 비즈니스 로직(포인트 차감, 중복/미소유 방지 등) 구현
- ApiException + ErrorCode 기반 예외 처리 일원화
- 아바타 관련 API(목록, 구매, 선택) 구현 및 테스트
- DB 컬럼명/엔티티 필드명 일치, createdAt 자동 기록 등 데이터 무결성 강화

## #️⃣연관된 이슈

> #40 

